### PR TITLE
Add ephemeral port monitor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.11
+
+RUN apk --no-cache add bash iproute2 nginx-mod-http-lua
+
+# Delete default config
+RUN rm -r /etc/nginx/conf.d && rm /etc/nginx/nginx.conf
+
+# Add nginx config
+ADD ./nginx.conf /etc/nginx/nginx.conf
+
+# Add collector
+ADD ./collect.sh /
+
+# Forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log
+
+RUN adduser -D -g 'www' www && \
+    chown -R www:www /var/lib/nginx && \
+    mkdir -p /run/nginx && chown -R www:www /run/nginx
+
+USER www:www
+
+EXPOSE 9090
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2013-2020 Glia Inc.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
 # Ephemeral Port Monitor
+
+This tool helps to monitor ephemeral port exhaustion. See
+https://making.pusher.com/ephemeral-port-exhaustion-and-how-to-avoid-it/ for
+more details about what is and how ephemeral port exhaustion happens.
+
+This tool collects ephemeral port usage using `ss` and returns it in
+OpenMetrics format.
+
+## Usage (kubernetes)
+
+Add annotation to your pod:
+
+```
+metadata:
+  annotations:
+    ad.datadoghq.com/ephemeral-port-monitor.check_names: '["openmetrics"]'
+    ad.datadoghq.com/ephemeral-port-monitor.init_configs: '[{}]'
+    ad.datadoghq.com/ephemeral-port-monitor.instances: |-
+      [
+        {
+          "prometheus_url": "http://%%host%%:9090/metrics",
+          "namespace": "transporter",
+          "metrics": ["system.net.used_ports.max_count", "system.net.used_ports.count"]
+        }
+      ]
+```
+
+Change the annotations in case you use something else than datadog.
+
+Add a new container:
+
+```
+spec:
+  containers:
+  - name: ephemeral-port-monitor
+    image: "salemove/ephemeral-port-monitor:0.1.0"
+    ports:
+    - name: http
+      containerPort: 9090
+    env:
+    - name: MIN_COUNT_TO_TRACK
+      value: "10"
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: http
+    readinessProbe:
+      httpGet:
+        path: /healthz
+        port: http
+```
+
+## Releasing a new version
+
+```bash
+docker build .
+docker tag <BUILD_ID> salemove/ephemeral-port-monitor:0.1.0
+docker push salemove/ephemeral-port-monitor:0.1.0
+```

--- a/collect.sh
+++ b/collect.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Collects information about ephemeral port usage.
+#
+# The container needs ss and awk:
+#   apk add iproute2
+
+set -euo pipefail
+
+# Sets minimal number of ports that have to be used for {local_ip + peer} group
+# before showing it in the metrics list.
+MIN_COUNT_TO_TRACK="${MIN_COUNT_TO_TRACK:-10}"
+
+min_local_port=$(cut -f 1 /proc/sys/net/ipv4/ip_local_port_range)
+max_local_port=$(cut -f 2 /proc/sys/net/ipv4/ip_local_port_range)
+
+# Connections are in this format:
+# State   Recv-Q   Send-Q   Local Address:Port   Peer Address::Port
+# ESTAB   0        0        10.4.134.246:54060   172.20.0.1:443
+fetch_connections() {
+  ss --numeric \
+     --no-header \
+     --ipv4 \
+     --tcp \
+     state connected "( sport >= :$min_local_port and sport <= :$max_local_port )"
+}
+
+format_connection_to_local_ip_with_peer() {
+  # Formats connection as "local_ip-peer_ip:peer_port"
+  awk -F":|[ \t]+" '{print $4 "-" $6 ":" $7}'
+}
+
+print_metrics() {
+  # Takes in lines of local ip with peer. We use uniques var to count each
+  # occurrence and then print it out in OpenMetrics format
+  #
+  # This is similar to `sort -u | uniq -c | awk '...'` but using awk for
+  # counting is a lot faster.
+  awk '
+    { uniques[$1]++ }
+    END {
+      for(key in uniques)
+        if (uniques[key] >= ENVIRON["MIN_COUNT_TO_TRACK"])
+          printf("system.net.used_ports.count{local_ip_with_peer=\"%s\"} %s\n", key, uniques[key])
+    }
+  '
+}
+
+echo "# TYPE system.net.used_ports.max_count gauge"
+echo "system.net.used_ports.max_count $((max_local_port-min_local_port))"
+
+echo "# TYPE system.net.used_ports.count gauge"
+fetch_connections | \
+  format_connection_to_local_ip_with_peer | \
+  print_metrics

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,31 @@
+load_module /usr/lib/nginx/modules/ndk_http_module.so;
+load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;
+pcre_jit on;
+
+worker_processes 1;
+
+events {
+  worker_connections 4;
+}
+
+http {
+  server {
+    listen 9090;
+    server_name localhost;
+
+    location /healthz {
+      return 204;
+    }
+
+    location /metrics {
+      default_type text/plain;
+      content_by_lua '
+        local handle = io.popen("/collect.sh")
+        local result = handle:read("*a")
+        handle.close()
+        ngx.print(result)
+      ';
+    }
+  }
+}
+


### PR DESCRIPTION
* collect.sh has all the collection logic
* Metrics are served with nginx (/metrics)

[1]: https://github.com/salemove/curl-job/

EN-5294