### PR TITLE
Increase worker_processes count to 2

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,7 +2,7 @@ load_module /usr/lib/nginx/modules/ndk_http_module.so;
 load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;
 pcre_jit on;
 
-worker_processes 1;
+worker_processes 2;
 
 events {
   worker_connections 4;


### PR DESCRIPTION
Fetching /metrics (which executes a script through lua) can block the
execution for multiple seconds. We don't want /healthz to be blocked
while we are fetching the metrics, because this could cause kubernetes
to think that the container is not alive.