### PR TITLE
Make metric names compliant with OpenMetrics conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ metadata:
         {
           "prometheus_url": "http://%%host%%:9090/metrics",
           "namespace": "transporter",
-          "metrics": ["system.net.used_ports.max_count", "system.net.used_ports.count"]
+          "metrics": [
+            {"system_net_used_ports_max_count": "system.net.used_ports.max_count"},
+            {"system_net_used_ports_count": "system.net.used_ports.count"}
+          ]
         }
       ]
 ```

--- a/collect.sh
+++ b/collect.sh
@@ -41,15 +41,15 @@ print_metrics() {
     END {
       for(key in uniques)
         if (uniques[key] >= min)
-          printf("system.net.used_ports.count{local_ip_with_peer=\"%s\"} %s\n", key, uniques[key])
+          printf("system_net_used_ports_count{local_ip_with_peer=\"%s\"} %s\n", key, uniques[key])
     }
   '
 }
 
-echo "# TYPE system.net.used_ports.max_count gauge"
-echo "system.net.used_ports.max_count $((max_local_port-min_local_port))"
+echo "# TYPE system_net_used_ports_max_count gauge"
+echo "system_net_used_ports_max_count $((max_local_port-min_local_port))"
 
-echo "# TYPE system.net.used_ports.count gauge"
+echo "# TYPE system_net_used_ports_count gauge"
 fetch_connections | \
   format_connection_to_local_ip_with_peer | \
   print_metrics


### PR DESCRIPTION
OpenMetrics does not allow dots in metric names. [1]
For some reason the previous versions of Datadog agent worked even if
dots were in the metric name. Newer versions of Datadog agent do not
allow dots in OpenMetrics metric names and due to that this metric
was not reported to Datadog.

To fix this issue we now use metric name that is compliant with
OpenMetrics naming.

Example has been modified to show how to map metric names
between OpenMetrics and Datadog.

[1]: https://prometheus.io/docs/practices/naming/